### PR TITLE
Handle integer ADC channel cfg

### DIFF
--- a/cfg
+++ b/cfg
@@ -116,6 +116,7 @@ def main(f,*kk):
                         v = s.subtree('devices',k,'adc',str(i))
                         flg=0
                         p=0
+                        if type(v) == int: v = str(v)
                         assert len(v)>=1 and len(v) <=3
                         for vv in v:
                             if vv >= '0' and vv <= '7':


### PR DESCRIPTION
An ADC spec like this failed, since the values are plain ints. Avoids having to explicitly use "1"

```
    adc:
      1: 0
      2: 1
      3: 2
```

```
./cfg world.cfg .hdr XXXX
Traceback (most recent call last):
  File "./cfg", line 357, in <module>
    main(*sys.argv[1:])
  File "./cfg", line 120, in main
    assert len(v)>=1 and len(v) <=3
TypeError: object of type 'int' has no len()
make[1]: *** [device/XXXX/dev_config.h] Error 1
```
