### PR TITLE
Mega8, ds2423 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ else # DEV is defined
 MCU:=$(shell $(RUN_CFG) ${CFG} devices.${DEV}.mcu)
 MCU_PROG:=$(shell $(RUN_CFG) ${CFG} devices.${DEV}.prog)
 PROG:=$(shell $(RUN_CFG) ${CFG} env.prog)
+AVRDUDE:=$(shell $(RUN_CFG) ${CFG} env.avrdude)
 
 CC=avr-gcc
 OBJCOPY:=avr-objcopy
@@ -102,8 +103,8 @@ burn_cfg:
 	@$(RUN_CFG) ${CFG} devices.${DEV}.defs.use_eeprom
 
 burn: burn_cfg all $(EE)
-	TF=$$(tempfile); echo "default_safemode = no;" >$$TF; \
-	sudo avrdude -c $(PROG) -p $(MCU_PROG) -C +$$TF \
+	TF=$$(mktemp avrdude-cfg.XXXXX); echo "default_safemode = no;" >$$TF; \
+	$(AVRDUDE) -c $(PROG) -p $(MCU_PROG) -C +$$TF\
 		-U flash:w:device/${DEV}/image.hex:i ${EEP} \
 		-U lfuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.l):m \
 		-U hfuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.h):m \
@@ -159,6 +160,8 @@ device/${DEV}/cfg: device/${DEV} ${CFG} cfg
 	@$(RUN_CFG) ${CFG} devices.${DEV}.prog
 	@echo -n PROG:
 	@$(RUN_CFG) ${CFG} env.prog
+	@echo -n AVRDUDE:
+	@$(RUN_CFG) ${CFG} env.avrdude
 	@echo -n CFILES:
 	@$(RUN_CFG) ${CFG} .cfiles ${DEV}
 	@echo -n TYPE:

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,13 @@ burn_cfg:
 
 burn: burn_cfg all $(EE)
 	TF=$$(mktemp avrdude-cfg.XXXXX); echo "default_safemode = no;" >$$TF; \
+	EFUSE=$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.e); \
+	[ "${EFUSE}" != "" ] && SET_EFUSE="-U efuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.e):m"; \
 	$(AVRDUDE) -c $(PROG) -p $(MCU_PROG) -C +$$TF\
 		-U flash:w:device/${DEV}/image.hex:i ${EEP} \
 		-U lfuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.l):m \
 		-U hfuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.h):m \
-		-U efuse:w:0x$(shell $(RUN_CFG) ${CFG} devices.${DEV}.fuse.e):m \
+		${SET_EFUSE} \
 	; X=$$?; rm $$TF; exit $$X
 endif # NO_BURN
 

--- a/adc.c
+++ b/adc.c
@@ -48,10 +48,10 @@ static inline char adc_check(adc_t *pp)
 	switch(poll_step++) {
 	case 0:
 		if (pp->flags & ADC_REF)
-			x = 0xE0;
+			x = (1<<REFS1) | (1<<REFS0) | (1<<ADLAR);
 		else
-			x = 0x60;
-		x |= (1<<ADLAR);
+			x = (1<<REFS0) |              (1<<ADLAR);
+
 		if (!(pp->flags & ADC_ALT)) 
 			x |= pp->flags&ADC_MASK;
 		else switch(pp->flags & ADC_MASK) {

--- a/cfg
+++ b/cfg
@@ -352,8 +352,8 @@ def main(cfg_name,*kk):
                         print("#define ONEWIRE_IRQNUM ({})".format(own), file=f)
                         if (own < 0):
                             print("#define ONEWIRE_IRQ INT{}_vect".format(-own-1), file=f)
-                            print("#define ONEWIRE_IER EIMSK", file=f)
-                            print("#define ONEWIRE_IFR EIFR", file=f)
+                            print("#define ONEWIRE_IER IMSK", file=f)
+                            print("#define ONEWIRE_IFR IFR", file=f)
                             print("#define ONEWIRE_IFBIT {}".format(1<<(-own-1)), file=f)
                         else:
                             print("#define ONEWIRE_IRQ PCINT{}_vect".format(own+int(owp[1])), file=f)

--- a/ds2423.c
+++ b/ds2423.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include "onewire.h"
 #include "features.h"
+#include "crc.h"
 #include "debug.h"
 
 #define C_WRITE_SCRATCHPAD 0x0F // TODO

--- a/ds2423.c
+++ b/ds2423.c
@@ -67,6 +67,14 @@ uint8_t debug_state;
 #define PINCHANGE_vect PCINT1_vect
 #define PCIE PCIE1
 #define PCMSK PCMSK1
+#elif defined (__AVR_ATmega8__)
+#define ADLARMUX (1<<ADLAR)
+#define ADPIN PINC
+// Mega8 does not have pinchange interupts
+// No digital solution impl for now
+//#define PINCHANGE_vect PCINT1_vect
+//#define PCIE PCIE1
+//#define PCMSK PCMSK1
 #else
 #warning Where is the ADLAR bit?
 #define NO_ADLAR
@@ -408,7 +416,9 @@ void init_state(void)
 	}
 
 	ADMUX = 0b1110 | (1<<REFS0) | ADLARMUX; // 5V ref
+#ifdef DIDR0
 	DIDR0 = (1<<NCOUNTERS)-1;
+#endif
 
 #if F_CPU >= 12800000 // prescale AD clock to <= 200 KHz
 #define CLK_A 7

--- a/ds2423.c
+++ b/ds2423.c
@@ -100,7 +100,9 @@ static uint16_t decay[NCOUNTERS];
 #endif
 #endif
 static uint8_t cur_adc,bstate;
+#if 0
 static uint16_t samples;
+#endif
 
 #else // !ANALOG
 volatile static uint8_t obits,cbits;
@@ -298,9 +300,13 @@ static inline void check_adc(void)
 			last[cur] = res;
 		} else if (res > hyst[cur]+last[cur]) {
 			bstate |= (1<<cur);
+#if 0
 			if(samples)
+#endif
+			{
 				counter[cur]++;
 				changed = 1;
+			}
 			last[cur] = res;
 		}
 	} else {
@@ -311,8 +317,10 @@ static inline void check_adc(void)
 			last[cur] = res;
 		}
 	}
+#if 0
 	if(samples < 0xFFFF)
 		samples++;
+#endif
 #else // !analog
 	uint8_t i = 0;
 	uint8_t now_bits,nbits,bits,ocbits;

--- a/ds2423.c
+++ b/ds2423.c
@@ -145,6 +145,9 @@ void do_mem_counter(void)
 	   between the second recv_byte_in() and xmit_byte() is less than a bit
 	   wide. That may not be enough time to update the CRC.
 	 */
+#ifdef CONDITIONAL_SEARCH
+	change_seen = 0;
+#endif
 	
 	recv_byte();
 	crc = crc16(crc,C_READ_MEM_COUNTER);
@@ -450,6 +453,11 @@ void init_state(void)
 	PCICR |= (1<<PCIE);
 #endif
 	PCMSK |= (1<<NCOUNTERS)-1;
+#endif
+
+#ifdef CONDITIONAL_SEARCH
+	// Init in alarm mode
+	change_seen = 1;
 #endif
 }
 

--- a/features.h
+++ b/features.h
@@ -68,7 +68,7 @@
 #define TIFR0 TIFR
 #define EEPE EEWE
 #define EEMPE EEMWE
-#define IFR EIFR
+#define IFR GIFR
 #endif
 
 #ifdef __AVR_ATtiny84__

--- a/onewire_internal.h
+++ b/onewire_internal.h
@@ -106,8 +106,14 @@ extern volatile uint8_t cbuf;  // char buffer, current byte to be (dis)assembled
 #define TIMER_INT ISR(TIMER2_OVF_vect) //the timer interrupt service routine
 
 #else
+#ifdef __AVR_ATmega8__
+// Not sure if this is valid for others as well?
+#define GTCCR SFIOR
+#define PSRSYNC PSR10
+#else
 #ifndef PSRSYNC
 #define PSRSYNC PSR0
+#endif
 #endif
 #define EN_TIMER() do {TIMSK0 |= (1<<TOIE0); TIFR0|=(1<<TOV0);}while(0) //enable timer interrupt
 #define DIS_TIMER() do {TIMSK0 &= ~(1<<TOIE0);} while(0) // disable timer interrupt

--- a/timer.c
+++ b/timer.c
@@ -78,7 +78,11 @@ void timer_reset(timer_t *t)
 
 void timer_init(void)
 {
+#if defined (__AVR_ATmega8__)
+#define TCCR0B TCCR0
+#else
 	TCCR0A=0;
+#endif
 #if PRESCALE==64
 	TCCR0B=0x03;
 #elif PRESCALE==256

--- a/world.cfg
+++ b/world.cfg
@@ -177,6 +177,12 @@ mcu:
     prog: t85
     defs:
       onewire_io: B1
+  mega8:
+    mcu: atmega8
+    prog: m8
+    flash:
+      size: 8
+      align: 32
   mega88:
     mcu: atmega88
     prog: m88
@@ -270,16 +276,10 @@ defaults:
         1: 2
         2: 3
         3: 4
-    m88:
-      _doc: basic atmega88 with internal crystal
-      _ref: mcu.mega88
+    m8x_base:
+      _doc: basic atmega8/atmega88, to be extended
       defs:
         f_cpu: 8000000
-      fuse:
-        l: xE2
-        h: xDC
-        e: x00
-        _doc: fuse.e might have to be xF8, depending on what the unused bits do
       port:
         1: B0~
         2: B1~
@@ -333,6 +333,23 @@ defaults:
         9: T-
         10: R
         11: G
+    m8:
+      _doc: basic atmega8 with internal crystal
+      _ref:
+        - defaults.target.m8x_base
+        - mcu.mega8
+      defs:
+        have_timer: 0
+    m88:
+      _doc: basic atmega88 with internal crystal
+      _ref:
+        - defaults.target.m8x_base
+        - mcu.mega88
+      fuse:
+        l: xE2
+        h: xDC
+        e: x00
+        _doc: fuse.e might have to be xF8, depending on what the unused bits do
     m88f:
       _doc: version of m88 with external crystal
       _ref: defaults.target.m88

--- a/world.cfg
+++ b/world.cfg
@@ -34,6 +34,7 @@ test:
     one: five
 env:
   prog: usbtiny
+  avrdude: sudo avrdude
 codes:
   _doc: Do not modify! These are also used by OWFS.
   onewire:

--- a/world.cfg
+++ b/world.cfg
@@ -497,6 +497,12 @@ devices:
     defs:
       is_onewire: ds2423
     onewire_id: xcacf2c9d0fef
+  test_ds2423_m8:
+    _ref: defaults.target.m8
+    defs:
+      analog: 1
+      is_onewire: ds2423
+    onewire_id: x13390287799c
   load88:
     _ref: defaults.target.m88
     defs:


### PR DESCRIPTION
Hi,

here are a couple of fixes to (re-?)enable build on ATmega8. Tested with DS2423 and moat.

The ds2423 code got a few analog fixes, since M8 does not have PCINT. Analog did not work at all before, I think (broken "samples" counter).

For the record:
I've tested the mega8 with 8Mhz internal osc, analog and 2 counters, and a pulse generator connected to both inputs (ADC0, ADC1).
With 100 pulses/s @ 0.3ms high / 9.7ms low it works, but it's pushing it. With 0.2ms high, it starts to skip a few, with 0.1ms high I loose about 50%.

Both my power meters run with 30ms long pulses, so for those kind of uses, this should be plenty enough to capture without any loss.

Johan
