### PR TITLE
Power saving features

### DIFF
--- a/adc.c
+++ b/adc.c
@@ -51,20 +51,37 @@ static inline char adc_check(adc_t *pp)
 			x = (1<<REFS1) | (1<<REFS0) | (1<<ADLAR);
 		else
 			x = (1<<REFS0) |              (1<<ADLAR);
+#ifdef __AVR_ATtiny84__
+#define _VGND 0x20
+#define _VBG 0x21
+#define _VTEMP 0x22
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+#define _VGND 0x0D
+#define _VBG 0x0C
+#define _VTEMP 0x0F
+#else
+// Valid for Mega88..168..328
+#define _VGND 0x0F
+#define _VBG 0x0E
+#define _VTEMP 0x08
+#endif
 
 		if (!(pp->flags & ADC_ALT)) 
 			x |= pp->flags&ADC_MASK;
 		else switch(pp->flags & ADC_MASK) {
 		case ADC_VBG:
-			x |= 0x0E; break;
+			x |= _VBG; break;
 		case ADC_VGND:
-			x |= 0x0F; break;
+			x |= _VGND; break;
 		case ADC_VTEMP:
-			x |= 0x08; break;
+			x |= _VTEMP; break;
 		default:
 			poll_step = 0;
 			return 1;
 		}
+#undef _VGND
+#undef _VBG
+#undef _VTEMP
 		ADMUX = x;
 		ADCSRA = (1<<ADEN)|(1<<ADIF)|0x07; // slow
 		break;

--- a/adc.c
+++ b/adc.c
@@ -136,6 +136,22 @@ void init_adc(void)
 		pp->flags &=~(ADC_IS_ALERT_L|ADC_IS_ALERT_H);
 		pp->lower = 0xFFFF;
 		pp->upper = 0x0000;
+#ifndef USE_ADC_AS_DIGITAL
+        // If pin is used as ADC, disable the digital logic buffer to save power.
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega88__) || defined (__AVR_ATmega328__)
+        // Only ADC0-5 have logic buffers
+        if(!(pp->flags & ADC_ALT) && (pp->flags & ADC_MASK) < 6) {
+            DIDR0|= (1 << (pp->flags & ADC_MASK));
+        }
+#elif defined (__AVR_ATtiny84__)
+        if(!(pp->flags & ADC_ALT)) {
+            DIDR0|= (1 << (pp->flags & ADC_MASK));
+        }
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+        // TODO: Proper support. ADC should be looked over on these
+        // devices generally, as it supports more complex channel configurations.
+#endif
+#endif
 		pp++;
 	}
 }

--- a/moat.c
+++ b/moat.c
@@ -249,6 +249,38 @@ void moat_init(void)
 		pf = pgm_read_ptr(&mc->init);
 		pf();
 	}
+
+	// Power reduction register allows us to turn off the clock to unused peripherals.
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega88__) || defined (__AVR_ATmega328__)
+   PRR =
+			(1 << PRTWI) // TWI not used at all
+        |(1 << PRSPI) // SPI not used at all
+        |(1 << PRTIM1) // Timer 1 not used at all
+			// Timer 2 is used for OW on Mega88
+#ifndef HAVE_TIMER
+        |(1 << PRTIM0)
+#endif
+#ifndef HAVE_UART
+        |(1 << PRUSART0)
+#endif
+#if !defined(N_ADC)
+        |(1 << PRADC)
+#endif
+		;
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)\
+	|| defined (__AVR_ATtiny84__)
+	PRR =
+			 (1 << PRTIM1) // Timer 1 not used at all
+			 // Timer 2 is used for OW on these devices
+#ifndef HAVE_UART
+			|(1 << PRUSI)
+#endif
+#if !defined(N_ADC)
+			|(1 << PRADC)
+#endif
+		;
+
+#endif
 }
 
 void do_command(uint8_t cmd)

--- a/world.cfg
+++ b/world.cfg
@@ -107,6 +107,7 @@ _doc:
         single_device: Add 1wire code for SKIP_ROM and READ_ROM
         need_bits: code needs to read/write single bits on 1wire bus
         onewire_io: hardware pin to use for 1wire
+        use_adc_as_digital: do not disable digital logic for ADC pins used as ADC (affects all ADC pins)
       pin_irq: 'mapping from pin to INT/PCINT. negative: INT(-n-1), otherwise PCINT(n+pin)'
       types:
         _doc:
@@ -133,6 +134,10 @@ _doc:
       - Add ! to switch A/C and B/D instead. (In that case, CD is 'high'.)
       - Add * to alert on state change. Setting a port sets the expected state to
         whatever you write.
+      - 'Note: If some pins are unused, it is recommended to ensure that these pins
+        have a defined level to reduce current consumption.
+        The way to do this with the MOAT device is to make them a "port"
+        input with pull-up enabled (suffix +).'
       pwm:
       - Number of the port to manage
       - Add * to alert if the PWM stops (zero value, i.e. one-shot)


### PR DESCRIPTION
I've added some features to shave of a few milliamps on power usage.

Some measurements on a Mega88A (TQFN32, 8Mhz internal), with nothing else on PCB except some 1n4148 in clamp-configuration over the ADC inputs. Nothing connected on any IOs otherwise (all pins floating).
Device configured as moat, with 8 ADC inputs and rest as ports.

Without pull-ups on all unused pins: 9.2mA
With pull-ups on all unused pins (by adding "ports" for all non-ADC pins): 8.2mA
With DIDR change applied too: 5.8mA
With PRR change applied too: 5.2mA.

Also added some improvements (untested) in tiny-class ADC.
