### PR TITLE
Added missing unused: [] default

### DIFF
--- a/world.cfg
+++ b/world.cfg
@@ -249,6 +249,7 @@ defaults:
         have_dbg_pin: 0
         have_tov0: 1
         console_ping: 0
+      unused: []
     m168:
       _doc: basic atmega168 with internal crystal
       _ref: mcu.mega168


### PR DESCRIPTION
A additional fix for building after unused support was added.