### PR TITLE
Fix builds with GCC 8 (was: add static on inline declarations where missing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ device/${DEV}/cfg: device/${DEV} ${CFG} cfg
 	@$(RUN_CFG) ${CFG} .type ${DEV}
 	@cp ${CFG} device/${DEV}/cfg
 device/${DEV}/image.hex: device/${DEV}/image.elf
-	$(OBJCOPY) -R .eeprom -O ihex $< $@
+	$(OBJCOPY) -j .data -j .text -O ihex $< $@
 device/${DEV}/image.lss: device/${DEV}/image.elf
 	$(OBJDUMP) -h -S $< > $@
 device/${DEV}/eprom.hex: device/${DEV}/image.elf

--- a/cfg
+++ b/cfg
@@ -513,6 +513,7 @@ def main(cfg_name,*kk):
                 if ow == "moat" and not BI:
                     files.extend(moat_files(s,k))
 
+                files.sort()  # Ensure object order is the same every time
                 print(" ".join(files))
             else:
                 print("Unknown mode:",mode, file=sys.stderr)

--- a/dev_data.c
+++ b/dev_data.c
@@ -39,7 +39,7 @@ extern uint8_t _config_end;
  *  Struct sizes must match exactly.
  */
 
-inline uint8_t cfg_byte(cfg_addr_t addr) {
+uint8_t inline cfg_byte(cfg_addr_t addr) {
 #ifdef USE_EEPROM
     return eeprom_read_byte(EEPROM_POS+addr);
 #else
@@ -183,7 +183,7 @@ char _cfg_read(void *data, uint8_t size, ConfigID id) {
 }
 
 #ifdef USE_EEPROM
-inline cfg_addr_t cfg_addr_w(uint8_t size, ConfigID id) {
+static inline cfg_addr_t cfg_addr_w(uint8_t size, ConfigID id) {
 	cfg_addr_t off;
 	uint8_t sz;
 

--- a/main.c
+++ b/main.c
@@ -101,7 +101,7 @@ init_all(void)
 	init_unused();
 }
 
-inline void
+static inline void
 poll_all(void)
 {
 #if defined(UART_DEBUG) && defined(N_CONSOLE)


### PR DESCRIPTION
I had problems building, giving weird errors:

```
/usr/local/opt/avr-binutils/bin/avr-ld: device/balcony_lightbox/main.o: in function `main':
/Users/johan/dev/moat/main.c:159: undefined reference to `poll_all'
collect2: error: ld returned 1 exit status
make[1]: *** [device/balcony_lightbox/image.elf] Error 1
```

Looking closer at a image.map from a previous build I noticed that it was built using `/usr/local/Cellar/avr-gcc@6/6.4.0/lib/avr-gcc/6/gcc/avr/6.4.0/`, now it used `/usr/local/Cellar/avr-gcc/8.2.0/lib/avr-gcc/8/gcc/avr/8.2.0/`.

Looks like it is caused by gcc 7 change: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81734