### PR TITLE
Fix watchdog timing constants for mega8

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,9 +52,13 @@ void setup_watchdog(void)
 	wdt_reset();
 #ifdef HAVE_IRQ_CATCHER
 	// intense debugging
-	wdt_enable(0x05);
+	wdt_enable(WDTO_500MS);
 #else
-	wdt_enable(0x09);
+#ifdef WDTO_4S
+	wdt_enable(WDTO_4S);
+#else
+	wdt_enable(WDTO_2S);
+#endif
 #endif
 #else
 	wdt_disable();


### PR DESCRIPTION
The timing constant 0x09 is valid for mega88 (4s) but not mega8, where we only have three bits. 0x09 & 0x7  => 0x1, which means 32.5ms.

Changed to use proper defines.